### PR TITLE
Converting module to be a capability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Publish
         env:
           NULLSTONE_ORG: nullstone
-          NULLSTONE_MODULE: aws-cdn
+          NULLSTONE_MODULE: aws-s3-cdn
           RELEASE_VERSION: ${{ steps.version.outputs.tag }}
         run: |-
           curl -XPOST -F "file=@module.tgz" -H "X-Nullstone-Key: ${{ secrets.NULLSTONE_API_KEY }}" \

--- a/aws.tf
+++ b/aws.tf
@@ -1,1 +1,0 @@
-provider "aws" {}

--- a/cert.tf
+++ b/cert.tf
@@ -1,20 +1,12 @@
 module "cert" {
-  source = "nullstone-modules/sslcert/aws"
+  source  = "nullstone-modules/sslcert/aws"
+  enabled = true
 
   domain = {
-    name    = local.main_subdomain
-    zone_id = local.main_zone_id
+    name    = local.subdomain
+    zone_id = local.zone_id
   }
 
   alternative_names = local.alt_subdomains
-  tags              = data.ns_workspace.this.tags
-  enabled           = local.has_domain
-
-  providers = {
-    aws.domain = aws.domain
-  }
-}
-
-locals {
-  cert_arn = local.has_domain ? module.cert[0].certificate_arn : data.ns_connection.subdomain.outputs.cert_arn
+  tags              = local.tags
 }

--- a/dns.tf
+++ b/dns.tf
@@ -1,39 +1,5 @@
-resource "aws_route53_record" "domain-root" {
-  provider = aws.domain
-
-  count = local.has_domain ? 1 : 0
-
-  zone_id = data.ns_connection.domain.outputs.zone_id
-  name    = ""
-  type    = "A"
-
-  alias {
-    name                   = aws_cloudfront_distribution.this.domain_name
-    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "domain-www" {
-  provider = aws.domain
-
-  count = local.has_domain && var.enable_www ? 1 : 0
-
-  zone_id = data.ns_connection.domain.outputs.zone_id
-  name    = "www"
-  type    = "A"
-
-  alias {
-    name                   = aws_cloudfront_distribution.this.domain_name
-    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
-    evaluate_target_health = true
-  }
-}
-
 resource "aws_route53_record" "subdomain-root" {
-  count = local.has_subdomain ? 1 : 0
-
-  zone_id = data.ns_connection.subdomain.outputs.zone_id
+  zone_id = local.zone_id
   name    = ""
   type    = "A"
 
@@ -45,9 +11,9 @@ resource "aws_route53_record" "subdomain-root" {
 }
 
 resource "aws_route53_record" "subdomain-www" {
-  count = local.has_subdomain && var.enable_www ? 1 : 0
+  count = var.enable_www ? 1 : 0
 
-  zone_id = data.ns_connection.subdomain.outputs.zone_id
+  zone_id = local.zone_id
   name    = "www"
   type    = "A"
 
@@ -56,11 +22,4 @@ resource "aws_route53_record" "subdomain-www" {
     zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
     evaluate_target_health = true
   }
-}
-
-locals {
-  main_subdomain = local.has_domain ? try(data.ns_connection.domain.outputs.fqdn, "") : try(data.ns_connection.subdomain.outputs.fqdn, "")
-  main_zone_id   = local.has_domain ? try(data.ns_connection.domain.outputs.zone_id, "") : try(data.ns_connection.subdomain.outputs.zone_id, "")
-  alt_subdomains = var.enable_www ? ["www.${local.main_subdomain}"] : []
-  all_subdomains = flatten([[local.main_subdomain], local.alt_subdomains])
 }

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -8,34 +8,16 @@ terraform {
 
 data "ns_workspace" "this" {}
 
-data "ns_connection" "domain" {
-  name     = "domain"
-  type     = "domain/aws"
-  optional = true
-}
-
 data "ns_connection" "subdomain" {
-  name     = "subdomain"
-  type     = "subdomain/aws"
-  optional = true
-}
-
-data "ns_connection" "origin" {
-  name = "origin"
-  type = "site/aws-s3"
+  name = "subdomain"
+  type = "subdomain/aws"
 }
 
 locals {
-  has_domain    = data.ns_connection.domain.workspace_id != ""
-  has_subdomain = data.ns_connection.subdomain.workspace_id != ""
-  zone_id       = try(data.ns_connection.domain.outputs.zone_id, data.ns_connection.subdomain.outputs.zone_id)
-}
+  tags = data.ns_workspace.this.tags
 
-// We will need to be able to support secondary providers since the root domain
-//   is typically managed in a separate account from non-production environments
-provider "aws" {
-  access_key = try(data.ns_connection.domain.outputs.delegator["access_key"], "")
-  secret_key = try(data.ns_connection.domain.outputs.delegator["secret_key"], "")
-
-  alias = "domain"
+  zone_id        = data.ns_connection.subdomain.outputs.zone_id
+  subdomain      = data.ns_connection.subdomain.outputs.fqdn
+  alt_subdomains = var.enable_www ? ["www.${local.subdomain}"] : []
+  all_subdomains = concat([local.subdomain], local.alt_subdomains)
 }

--- a/origin.tf
+++ b/origin.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudfront_origin_access_identity" "this" {
+  comment = "${local.resource_name} Managed by Terraform"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,15 @@
-output "cdn_arn" {
-  value       = aws_cloudfront_distribution.this.arn
-  description = "string ||| CloudFront Distribution ARN"
+output "origin_access_identities" {
+  value = [
+    {
+      iam_arn = aws_cloudfront_origin_access_identity.this.iam_arn
+    }
+  ]
 }
 
-output "cert_arn" {
-  value       = local.cert_arn
-  description = "string ||| SSL Certificate ARN"
+locals {
+  public_fqdns = concat([aws_route53_record.subdomain-root.fqdn], aws_route53_record.subdomain-www.*.fqdn)
+}
+
+output "public_urls" {
+  value = [for pu in local.public_fqdns : { url = trimsuffix(pu, ".") }]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,19 @@
+variable "app_metadata" {
+  description = <<EOF
+App Metadata is injected from the app on-the-fly.
+This contains information about resources created in the app module that are needed by the capability.
+EOF
+
+  type    = map(string)
+  default = {}
+}
+
+variable "index" {
+  type        = string
+  description = "The default document to use when hitting the root of the site."
+  default     = "index.html"
+}
+
 variable "enable_www" {
   type        = bool
   description = "Enable/Disable creating www.<domain> DNS record in addition to <domain> DNS record for hosted site"


### PR DESCRIPTION
This PR converts the cdn module into an app capability.
While not enforced, this cdn will only work with `type=site/aws-s3`.

## TODO
- [x] Set `aws-cdn` module to draft.
- [x] Create `aws-cdn-s3` module with `category=capability`, `type=capability/cdn/aws`.
- [ ] Redeploy nullstone docs site using this capability.