### PR TITLE
Fix initial provision when app_version is blank

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -28,7 +28,10 @@ resource "aws_cloudfront_distribution" "this" {
   origin {
     domain_name = local.s3_domain_name
     origin_id   = local.s3_origin_id
-    origin_path = "/${local.app_version}"
+
+    // origin_path cannot end with a '/'
+    // If app_version is '', then we want origin_path = '' (this happens upon initial provision)
+    origin_path = trimsuffix("/${local.app_version}", "/")
 
     s3_origin_config {
       origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path


### PR DESCRIPTION
This PR fixes the initial provisioning of a CDN.

Cloudfront explicitly says that `origin_path` cannot end with a `/`.
This will force the CDN to be blank when app_version is blank.