### PR TITLE
forcing cert region to us-east-1

### DIFF
--- a/cert.tf
+++ b/cert.tf
@@ -11,6 +11,7 @@ module "cert" {
   tags              = local.tags
 
   providers = {
+    aws        = aws.cert
     aws.domain = aws.domain
   }
 }

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -28,3 +28,11 @@ provider "aws" {
 
   alias = "domain"
 }
+
+// When attaching certificates to a CDN, the cert must live in the us-east-1 region
+// See https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-invalid-viewer-certificate/
+provider "aws" {
+  region = "us-east-1"
+
+  alias = "cert"
+}


### PR DESCRIPTION
This change fixed the issue. The cert is now being created in us-east-1 and cloudfront is able to use it correctly.