### PR TITLE
C568 env vars

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - 'v*'
 
+env:
+  NULLSTONE_ORG: nullstone
+  NULLSTONE_API_KEY: ${{ secrets.NULLSTONE_API_KEY }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -17,20 +21,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # Package files into tgz
-      - name: Package
-        run: tar -cvzf module.tgz *.tf README.md
-
       - name: Find version
         id: version
         run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
 
-      # Publish to nullstone
-      - name: Publish
-        env:
-          NULLSTONE_ORG: nullstone
-          NULLSTONE_MODULE: aws-s3-cdn
-          RELEASE_VERSION: ${{ steps.version.outputs.tag }}
-        run: |-
-          curl -XPOST -F "file=@module.tgz" -H "X-Nullstone-Key: ${{ secrets.NULLSTONE_API_KEY }}" \
-            https://api.nullstone.io/orgs/${NULLSTONE_ORG}/modules/${NULLSTONE_MODULE}/versions?version=${RELEASE_VERSION}
+      - name: Set up Nullstone
+        uses: nullstone-io/setup-nullstone-action@v0
+
+      - name: Publish module
+        run: |
+          nullstone modules publish --version=${{ steps.version.outputs.tag }}

--- a/cdn.tf
+++ b/cdn.tf
@@ -70,14 +70,22 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   ordered_cache_behavior {
-    allowed_methods        = ["GET"]
-    cached_methods         = ["GET"]
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
     path_pattern           = "env.json"
     target_origin_id       = local.s3_env_origin_id
     viewer_protocol_policy = "https-only"
     min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 31536000
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
   }
 
   restrictions {

--- a/cdn.tf
+++ b/cdn.tf
@@ -1,12 +1,21 @@
 locals {
-  normalized_404_page = "/${trimprefix(var.notfound_document, "/")}"
-  custom_404 = {
+  normalized_404_page = "/${trimprefix(var.notfound_behavior.document, "/")}"
+  normal_404_behavior = {
     error_code    = 404,
     response_code = 404,
     cache_ttl     = 0,
     path          = local.normalized_404_page
   }
-  custom_errors = var.enable_404page ? [local.custom_404] : []
+  normalized_default_doc = "/${trimprefix(var.default_document, "/")}"
+  spa_404_behavior       = {
+    error_code    = 404
+    response_code = 200
+    cache_ttl     = 0,
+    path          = local.normalized_default_doc
+  }
+  custom_404 = var.notfound_behavior.spa_mode ? local.spa_404_behavior : local.normal_404_behavior
+
+  custom_errors = var.notfound_behavior.enabled ? [local.custom_404] : []
 
   s3_domain_name   = var.app_metadata["s3_domain_name"]
   s3_origin_id     = "S3-${var.app_metadata["s3_bucket_id"]}"

--- a/variables.tf
+++ b/variables.tf
@@ -20,14 +20,22 @@ variable "default_document" {
   default     = "index.html"
 }
 
-variable "enable_404page" {
-  type        = bool
-  description = "Enable/Disable custom 404 page within s3 bucket. If enabled, must provide 404.html"
-  default     = false
-}
+variable "notfound_behavior" {
+  type = object({
+    enabled : bool
+    spa_mode : bool
+    document : string
+  })
 
-variable "notfound_document" {
-  type        = string
-  description = "The document to use when the page is not found. By default, /404.html"
-  default     = "404.html"
+  default = {
+    enabled  = true
+    spa_mode = true
+    document = "404.html"
+  }
+
+  description = <<EOF
+This configures behavior when a file is not found.
+If `spa_mode` is on, all not found errors will respond with `HTTP 200` serving `default_document`.
+Otherwise, will respond with `HTTP 404` serving `document`.
+EOF
 }


### PR DESCRIPTION
This upgrades the CDN to support environment variables stored in `s3://<artifacts-bucket>/env.json`.

Normally, the CDN is configured to serve content from `s3://<artifacts-bucket>/<app-version>/<requested-file>`.
With this PR, a request with `requested-file=env.json` will serve content from `s3://<artifacts-bucket>/env.json` instead.

This allows the static site module to update `env.json` at will without worrying about what application version is currently in use.

Updated to use nullstone github action to publish module.