### PR TITLE
Add support for unversioned assets

### DIFF
--- a/cdn.tf
+++ b/cdn.tf
@@ -22,9 +22,10 @@ locals {
   s3_env_origin_id = "S3-Env-${var.app_metadata["s3_bucket_id"]}"
 
   // Use artifacts_key_template injected by the app module
-  // Since origin_path cannot end with a '/', we need to strip that from the end
-  // If app_version is '', then we want origin_path = '' (this happens upon initial provision)
-  origin_path = local.app_version == "" ? "" : trimsuffix(replace(local.artifacts_key_template, "{{app-version}}", local.app_version), "/")
+  // A valid origin_path has a preceding `/` and no trailing `/`
+  // `/` is invalid -- this will force empty string
+  artifacts_dir = trimprefix(replace(local.artifacts_key_template, "{{app-version}}", local.app_version), "/")
+  origin_path   = trimsuffix("/${local.artifacts_dir}", "/")
 }
 
 resource "aws_cloudfront_distribution" "this" {

--- a/cdn.tf
+++ b/cdn.tf
@@ -20,6 +20,11 @@ locals {
   s3_domain_name   = var.app_metadata["s3_domain_name"]
   s3_origin_id     = "S3-${var.app_metadata["s3_bucket_id"]}"
   s3_env_origin_id = "S3-Env-${var.app_metadata["s3_bucket_id"]}"
+
+  // Use artifacts_key_template injected by the app module
+  // Since origin_path cannot end with a '/', we need to strip that from the end
+  // If app_version is '', then we want origin_path = '' (this happens upon initial provision)
+  origin_path = local.app_version == "" ? "" : trimsuffix(replace(local.artifacts_key_template, "{{app-version}}", local.app_version), "/")
 }
 
 resource "aws_cloudfront_distribution" "this" {
@@ -40,9 +45,7 @@ resource "aws_cloudfront_distribution" "this" {
     domain_name = local.s3_domain_name
     origin_id   = local.s3_origin_id
 
-    // origin_path cannot end with a '/'
-    // If app_version is '', then we want origin_path = '' (this happens upon initial provision)
-    origin_path = trimsuffix("/${local.app_version}", "/")
+    origin_path = local.origin_path
 
     s3_origin_config {
       origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ EOF
   default = {}
 }
 
+locals {
+  // Older versions of the static site module don't have this, fallback to versioned assets
+  artifacts_key_template = try(var.app_metadata["artifacts_key_template"], "{{app-version}}/")
+}
+
 variable "enable_www" {
   type        = bool
   description = "Enable/Disable creating www.<domain> DNS record in addition to <domain> DNS record for hosted site"


### PR DESCRIPTION
This updates the CDN to support versioned assets in s3 static sites.
The injected `artifacts_key_template` from `app_metadata` is used to configure the origin path on the CDN instead of being hardcoded.

If the app module does not have support, this module will fall back to the current behavior.
As a result, this PR can merge independent of https://github.com/nullstone-modules/aws-s3-site/pull/8