### PR TITLE
Improve standard options and switch to managed policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.9.0 (May 15, 2023)
+* Allow configuration of Cache Policy. Default: `CachingOptimized`
+* Allow configuration of Response Headers Policy. Default: `CORS-with-preflight-and-SecurityHeadersPolicy`
+* Add variables `min_ttl`, `default_ttl`, and `max_ttl` to configure caching.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# block-aws-cdn
+# CDN for S3 Site
 
-Nullstone Block provisions an AWS CloudFront Distribution (CDN) and an SSL Certificate against a subdomain chosen 
+Creates an AWS CloudFront Distribution (CDN) with an SSL Certificate against a subdomain created as another block.
+
+
 
 ## Inputs
 

--- a/subdomain.tf
+++ b/subdomain.tf
@@ -1,6 +1,5 @@
 data "ns_connection" "subdomain" {
   name     = "subdomain"
-  type     = "subdomain/aws"
   contract = "subdomain/aws/route53"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,49 @@ If `spa_mode` is on, all not found errors will respond with `HTTP 200` serving `
 Otherwise, will respond with `HTTP 404` serving `document`.
 EOF
 }
+
+variable "min_ttl" {
+  type        = number
+  default     = 0
+  description = <<EOF
+Minimum amount of time that you want objects to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated.
+Defaults to 0 seconds.
+EOF
+}
+
+variable "default_ttl" {
+  type        = number
+  default     = 86400
+  description = <<EOF
+Default amount of time (in seconds) that an object is in a CloudFront cache before CloudFront forwards another request in the absence of an Cache-Control max-age or Expires header.
+EOF
+}
+
+variable "max_ttl" {
+  type        = number
+  default     = 31536000
+  description = <<EOF
+Maximum amount of time (in seconds) that an object is in a CloudFront cache before CloudFront forwards another request to your origin to determine whether the object has been updated.
+Only effective in the presence of Cache-Control max-age, Cache-Control s-maxage, and Expires headers.
+EOF
+}
+
+variable "cache_policy" {
+  type = string
+  default = "CachingOptimized"
+  description = <<EOF
+Set the policy for how the CDN caches objects.
+By default, the CDN is configured with `CachingOptimized`.
+You can choose a custom policy or AWS-managed policy.
+EOF
+}
+
+variable "response_headers_policy" {
+  type        = string
+  default     = "CORS-with-preflight-and-SecurityHeadersPolicy"
+  description = <<EOF
+Set the policy for the response headers on the CDN.
+By default, the CDN is configured with CORS (preflight) and security headers.
+You can choose a custom policy or AWS-managed policy.
+EOF
+}

--- a/variables.tf
+++ b/variables.tf
@@ -72,8 +72,8 @@ EOF
 }
 
 variable "cache_policy" {
-  type = string
-  default = "CachingOptimized"
+  type        = string
+  default     = "CachingOptimized"
   description = <<EOF
 Set the policy for how the CDN caches objects.
 By default, the CDN is configured with `CachingOptimized`.


### PR DESCRIPTION
* Allow configuration of Cache Policy. Default: `CachingOptimized`
* Allow configuration of Response Headers Policy. Default: `CORS-with-preflight-and-SecurityHeadersPolicy`
* Add variables `min_ttl`, `default_ttl`, and `max_ttl` to configure caching.
