### PR TITLE
F/logs metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0 (Nov 11, 2025)
+* Added access logs to CloudFront distribution (accessible via Nullstone logs).
+* Added metrics mappings to show CloudFront metrics in Nullstone.
+
 # 0.9.4 (Jun 16, 2025)
 * Fixed skip certificate creation when subdomain has a certificate already.
 

--- a/aws.tf
+++ b/aws.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}

--- a/logging.tf
+++ b/logging.tf
@@ -1,0 +1,22 @@
+resource "aws_cloudwatch_log_delivery_destination" "access_logs" {
+  name          = "${local.resource_name}-access-logs"
+  output_format = "json"
+  tags          = local.tags
+
+  delivery_destination_configuration {
+    destination_resource_arn = local.log_group_arn
+  }
+}
+
+resource "aws_cloudwatch_log_delivery_source" "access_logs" {
+  name         = "${local.resource_name}-access-logs"
+  log_type     = "ACCESS_LOGS"
+  resource_arn = aws_cloudfront_distribution.this.arn
+  tags         = local.tags
+}
+
+resource "aws_cloudwatch_log_delivery" "access_logs" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.access_logs.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.access_logs.arn
+  tags                     = local.tags
+}

--- a/metrics.tf
+++ b/metrics.tf
@@ -1,0 +1,61 @@
+locals {
+  dims = tomap({
+    "DistributionId" = aws_cloudfront_distribution.this.id
+  })
+
+  metric_name_prefix = "cdn/${random_string.resource_suffix.result}"
+
+  metrics = [
+    {
+      name = "${local.metric_name_prefix}/requests"
+      type = "generic"
+      unit = "count"
+
+      mappings = {
+        requests_total = {
+          account_id  = local.account_id
+          stat        = "Sum"
+          namespace   = "AWS/CloudFront"
+          metric_name = "Requests"
+          dimensions  = local.dims
+        }
+        requests_5xx = {
+          account_id  = local.account_id
+          stat        = "Sum"
+          namespace   = "AWS/CloudFront"
+          metric_name = "4xxErrorRate"
+          dimensions  = local.dims
+        }
+        requests_4xx = {
+          account_id  = local.account_id
+          stat        = "Sum"
+          namespace   = "AWS/CloudFront"
+          metric_name = "5xxErrorRate"
+          dimensions  = local.dims
+        }
+      }
+    },
+    {
+      name = "${local.metric_name_prefix}/transfer"
+      type = "generic"
+      unit = "bytes"
+
+      mappings = {
+        download = {
+          account_id  = local.account_id
+          stat        = "Sum"
+          namespace   = "AWS/CloudFront"
+          metric_name = "BytesDownloaded"
+          dimensions  = local.dims
+        }
+        upload = {
+          account_id  = local.account_id
+          stat        = "Sum"
+          namespace   = "AWS/CloudFront"
+          metric_name = "BytesUploaded"
+          dimensions  = local.dims
+        }
+      }
+    }
+  ]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,14 @@ locals {
 output "public_urls" {
   value = [for pu in local.public_fqdns : { url = "https://${trimsuffix(pu, ".")}" }]
 }
+
+output "metrics" {
+  value = [
+    for m in local.metrics : {
+      name     = m.name
+      type     = m.type
+      unit     = m.unit
+      mappings = jsonencode(m.mappings)
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,8 @@ EOF
 locals {
   // Older versions of the static site module don't have this, fallback to versioned assets
   artifacts_key_template = try(var.app_metadata["artifacts_key_template"], "{{app-version}}/")
+  log_group_name         = try(var.app_metadata["log_group_name"], "")
+  log_group_arn          = try(var.app_metadata["log_group_arn"], "")
 }
 
 variable "enable_www" {


### PR DESCRIPTION
This configures the CloudFront to emit access logs to a cloudwatch log group created by the app module.
Additionally, this emits metrics for display on the Nullstone Monitoring tab.